### PR TITLE
Implements the API endpoints section of the quiz

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,3 @@
+# Basic Auth
+export AUTH_USER=webvolta
+export AUTH_PASSWORD=123456

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ tags
 
 # Ignore ide settings
 /.idea
+
+# Ignore direnv file
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# Ignore ide settings
+/.idea

--- a/Gemfile
+++ b/Gemfile
@@ -14,18 +14,19 @@ gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem 'slim-rails'
 gem "jsbundling-rails"
+gem 'kaminari'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
   gem "pry-rails"
+  gem "faker"
 end
 
 group :development do
   gem "web-console"
   gem "annotate"
-  gem "faker"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1)
@@ -268,6 +270,7 @@ GEM
     zeitwerk (2.5.3)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,18 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.0.0)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -282,6 +294,7 @@ DEPENDENCIES
   faker
   jbuilder
   jsbundling-rails
+  kaminari
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please make your solutions to this application as if you're doing your every day
 
 ### Performance Issues
 2. Too many queries to the database, load Companies along with People.
-3. As a front-end user, when viewing more than 10 entries in the index, I will see them raginated (with Kaminari).
+3. As a front-end user, when viewing more than 10 entries in the index, I will see them paginated (with Kaminari).
 
 ### Issue User Stories
 4. As a front-end user, when creating a new Person entry, when the new entry is unable to be saved, I will see a message with the error, and it will keep the values in the fields I have already filled out. 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,20 @@
+class Api::ApiController < ActionController::API
+  private
+
+  def render_query(klass)
+    query = initialize_query(klass)
+    render json: query.call
+  end
+
+  def initialize_query(klass)
+    klass.new(filters: filter_params(klass), paging: paging_params)
+  end
+
+  def paging_params
+    params.permit(:page, :per_page)
+  end
+
+  def filter_params(klass)
+    params.permit(klass::FILTERS)
+  end
+end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,5 +1,14 @@
 class Api::ApiController < ActionController::API
+  include ActionController::HttpAuthentication::Basic::ControllerMethods
+
   private
+
+  def render_validated_action(error_message:)
+    result = yield
+    render json: result
+  rescue ActiveRecord::RecordInvalid
+    render json: { error: error_message }, status: :bad_request
+  end
 
   def render_query(klass)
     query = initialize_query(klass)

--- a/app/controllers/api/companies_controller.rb
+++ b/app/controllers/api/companies_controller.rb
@@ -1,5 +1,21 @@
 class Api::CompaniesController < Api::ApiController
+  http_basic_authenticate_with name: ENV.fetch('AUTH_USER'),
+                               password: ENV.fetch('AUTH_PASSWORD'),
+                               only: :create
+
   def index
     render_query CompanyQuery
+  end
+
+  def create
+    render_validated_action(error_message: "Failed to create companies!") do
+      Company.create!(create_params)
+    end
+  end
+
+  private
+
+  def create_params
+    params.permit(companies: [:name]).require(:companies)
   end
 end

--- a/app/controllers/api/companies_controller.rb
+++ b/app/controllers/api/companies_controller.rb
@@ -1,0 +1,5 @@
+class Api::CompaniesController < Api::ApiController
+  def index
+    render_query CompanyQuery
+  end
+end

--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -1,0 +1,5 @@
+class Api::PeopleController < Api::ApiController
+  def index
+    render_query PersonQuery
+  end
+end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -19,7 +19,7 @@ class PeopleController < ApplicationController
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,6 +9,8 @@
 #
 
 class Company < ApplicationRecord
+  validates :name, presence: true
+
   has_many :people
 
   scope :by_name_like, ->(name) {

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -10,4 +10,9 @@
 
 class Company < ApplicationRecord
   has_many :people
+
+  scope :by_name_like, ->(name) {
+    # NOTE: this can get dicey w/r/t bypassing indexes depending on the DB, but keeping things simple for now
+    where("lower(companies.name) like :name", name: "%#{name.downcase}%")
+  }
 end

--- a/app/queries/company_query.rb
+++ b/app/queries/company_query.rb
@@ -1,0 +1,11 @@
+class CompanyQuery
+  include BaseQuery
+
+  FILTERS = [:name].freeze
+
+  def initialize(filters: {}, paging: {})
+    @scope = Company.order(:name)
+    @scope = @scope.by_name_like(filters[:name]) if filters[:name]
+    @scope = apply_paging(@scope, paging)
+  end
+end

--- a/app/queries/concerns/base_query.rb
+++ b/app/queries/concerns/base_query.rb
@@ -1,0 +1,27 @@
+module BaseQuery
+  extend ActiveSupport::Concern
+
+  DEFAULT_PAGE = 1
+  DEFAULT_PER_PAGE = 10
+
+  def call
+    @scope
+  end
+
+  private
+
+  def apply_paging(scope, paging)
+    page = normalize_param(paging, :page, DEFAULT_PAGE)
+    per_page = normalize_param(paging, :per_page, DEFAULT_PER_PAGE)
+    scope.page(page).per(per_page)
+  end
+
+  def normalize_param(paging, param_name, default_value)
+    value = paging[param_name].to_i
+    if value <= 0
+      default_value
+    else
+      value
+    end
+  end
+end

--- a/app/queries/person_query.rb
+++ b/app/queries/person_query.rb
@@ -1,0 +1,11 @@
+class PersonQuery
+  include BaseQuery
+
+  FILTERS = [:email].freeze
+
+  def initialize(filters: {}, paging: {})
+    @scope = Person.order(:name)
+    @scope = @scope.where(email: filters[:email]) if filters[:email]
+    @scope = apply_paging(@scope, paging)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :people, only: [:index]
-    resources :companies, only: [:index]
+    resources :companies, only: [:index, :create]
   end
 
   root to: 'people#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
 
   resources :people, only: [:index, :new, :create]
+
+  namespace :api do
+    resources :people, only: [:index]
+    resources :companies, only: [:index]
+  end
+
   root to: 'people#index'
 end

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :company do
+    name { Faker::Company.name }
+  end
+end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :person do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    phone_number { Faker::PhoneNumber.phone_number }
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -12,4 +12,5 @@ require 'rails_helper'
 
 RSpec.describe Company, type: :model do
   it { is_expected.to have_many :people }
+  it { is_expected.to validate_presence_of(:name) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -63,6 +63,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include AuthHelper
 end
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/requests/api/companies/create_spec.rb
+++ b/spec/requests/api/companies/create_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'POST api/companies', type: :request do
+  let(:companies_params) { { companies: [{ name: 'ABC Co.' }, name: 'XYZ Inc.'] } }
+
+  context 'authorized' do
+    it 'should create valid companies' do
+      post '/api/companies', params: companies_params, headers: basic_auth_header
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to have_http_status(200)
+      expect(json.first[:id]).not_to be_nil
+      expect(json.first[:name]).to eq('ABC Co.')
+      expect(json.last[:id]).not_to be_nil
+      expect(json.last[:name]).to eq('XYZ Inc.')
+    end
+
+    it 'should not create invalid companies' do
+      invalid_params = { companies: [name: nil] }
+
+      post '/api/companies', params: invalid_params, headers: basic_auth_header
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to have_http_status(400)
+      expect("Failed to create companies!").to eq(json[:error])
+    end
+  end
+
+  context 'not authorized' do
+    it 'should not process the request' do
+      post '/api/companies', params: companies_params
+      expect(response).to have_http_status(401)
+    end
+  end
+end

--- a/spec/requests/api/companies/index_spec.rb
+++ b/spec/requests/api/companies/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'api/companies', type: :request do
+describe 'GET api/companies', type: :request do
   before do
     @companies = FactoryBot.create_list(:company, 21)
     @companies = @companies.sort_by(&:name)

--- a/spec/requests/api/companies/index_spec.rb
+++ b/spec/requests/api/companies/index_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe 'api/companies', type: :request do
+  before do
+    @companies = FactoryBot.create_list(:company, 21)
+    @companies = @companies.sort_by(&:name)
+  end
+
+  it 'should return a list of companies sorted by name using default paging' do
+    expected_companies = @companies.take(10)
+
+    get "/api/companies"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(10)
+    expect(expected_companies.first.id).to eq(json.first[:id])
+    expect(expected_companies.last.id).to eq(json.last[:id])
+  end
+
+  it 'should return a list of companies sorted by name using the paging params' do
+    expected_companies = @companies.slice(5, 5)
+
+    get "/api/companies?page=2&per_page=5"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(5)
+    expect(expected_companies.first.id).to eq(json.first[:id])
+    expect(expected_companies.last.id).to eq(json.last[:id])
+  end
+
+  it 'should return a the last company on the last page' do
+    expected_company = @companies.last
+
+    get "/api/companies?page=3&per_page=10"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(1)
+    expect(expected_company.id).to eq(json.first[:id])
+  end
+
+  it 'should return a list of companies sorted by name using the name filter' do
+    company1 = @companies.first
+    company2 = @companies.last
+    company1.update_column(:name, 'We Make Widgets Corp')
+    company2.update_column(:name, 'ABC WIDGETS INC')
+
+    get "/api/companies?name=wIDgetS"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(2)
+    expect(company2.id).to eq(json.first[:id])
+    expect(company1.id).to eq(json.last[:id])
+  end
+
+  it 'should handle requests beyond the max page' do
+    get "/api/companies?page=99&per_page=5"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(0)
+    expect([]).to eq(json)
+  end
+
+  it 'should ignore a bogus page value' do
+    expected_companies = @companies.take(10)
+
+    get "/api/companies?page=foo&per_page=10"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(10)
+    expect(expected_companies.first.id).to eq(json.first[:id])
+    expect(expected_companies.last.id).to eq(json.last[:id])
+  end
+
+  it 'should ignore a bogus per page value' do
+    expected_companies = @companies.take(10)
+
+    get "/api/companies?page=1&per_page=foo"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(10)
+    expect(expected_companies.first.id).to eq(json.first[:id])
+    expect(expected_companies.last.id).to eq(json.last[:id])
+  end
+end

--- a/spec/requests/api/people/index_spec.rb
+++ b/spec/requests/api/people/index_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe 'api/people', type: :request do
+  before do
+    @people = FactoryBot.create_list(:person, 21)
+    @people = @people.sort_by(&:name)
+  end
+
+  it 'should return a list of people sorted by name using default paging' do
+    expected_people = @people.take(10)
+
+    get "/api/people"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(10)
+    expect(expected_people.first.id).to eq(json.first[:id])
+    expect(expected_people.last.id).to eq(json.last[:id])
+  end
+
+  it 'should return a list of people sorted by name using the paging params' do
+    expected_people = @people.slice(5, 5)
+
+    get "/api/people?page=2&per_page=5"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(5)
+    expect(expected_people.first.id).to eq(json.first[:id])
+    expect(expected_people.last.id).to eq(json.last[:id])
+  end
+
+  it 'should return a the last person on the last page' do
+    expected_person = @people.last
+
+    get "/api/people?page=3&per_page=10"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(1)
+    expect(expected_person.id).to eq(json.first[:id])
+  end
+
+  it 'should return a list of people sorted by name using the email filter' do
+    random_people = @people.shuffle
+    expected_people = [random_people.first, random_people.last].sort_by(&:name)
+    expected_people.each { |person| person.update_column(:email, 'foo@bar.com') }
+
+    get "/api/people?email=foo@bar.com"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(2)
+    expect(expected_people.first.id).to eq(json.first[:id])
+    expect(expected_people.last.id).to eq(json.last[:id])
+  end
+
+  it 'should handle requests beyond the max page' do
+    get "/api/people?page=99&per_page=5"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(0)
+    expect([]).to eq(json)
+  end
+
+  it 'should ignore a bogus page value' do
+    expected_people = @people.take(10)
+
+    get "/api/people?page=foo&per_page=10"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(10)
+    expect(expected_people.first.id).to eq(json.first[:id])
+    expect(expected_people.last.id).to eq(json.last[:id])
+  end
+
+  it 'should ignore a bogus per page value' do
+    expected_people = @people.take(10)
+
+    get "/api/people?page=1&per_page=foo"
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to have_http_status(200)
+    expect(json.size).to eq(10)
+    expect(expected_people.first.id).to eq(json.first[:id])
+    expect(expected_people.last.id).to eq(json.last[:id])
+  end  
+end

--- a/spec/requests/api/people/index_spec.rb
+++ b/spec/requests/api/people/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'api/people', type: :request do
+describe 'GET api/people', type: :request do
   before do
     @people = FactoryBot.create_list(:person, 21)
     @people = @people.sort_by(&:name)

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,0 +1,8 @@
+module AuthHelper
+  def basic_auth_header
+    user = ENV.fetch('AUTH_USER')
+    password = ENV.fetch('AUTH_PASSWORD')
+    encoded_authorization = ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
+    { 'HTTP_AUTHORIZATION' => encoded_authorization }
+  end
+end


### PR DESCRIPTION
In the interest of time, I only laid down tests for the API layer itself. Typically, I'll also add tests for the `*Query` classes and `scopes` so that they can be reliably decoupled from the API and reused in other parts of the application, but that seemed like overkill in this case. I also left versioning out of the `api` namespace, but this is obviously something you'd want in a production scenario.

For the basic auth environment variables I used `direnv`.

`brew install direnv`
