### PR TITLE
Show error messages and preserve values in People entry form on failure

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,17 +9,22 @@ class PeopleController < ApplicationController
   end
 
   def create
-    if Person.create(person_attributes)
+    @person = Person.new(person_attributes)
+
+    if @person.save
       redirect_to people_path, notice: 'Successfully created entry'
     else
-      render :create, alert: 'Unsuccessfully created entry'
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@person, partial: 'people/form', locals: { person: @person }) }
+        format.html { render :new }
+      end
     end
   end
 
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -14,4 +14,6 @@
 class Person < ApplicationRecord
   
   belongs_to :company, optional: true
+
+  validates :name, presence: true
 end

--- a/app/views/people/_form.html.slim
+++ b/app/views/people/_form.html.slim
@@ -1,0 +1,17 @@
+= form_for @person, class: 'row' do |f|
+  - if @person.errors.any?
+    .errors.alert-danger.mt-3
+      ul
+        - @person.errors.full_messages.each do |message|
+          li= message
+  .col-auto
+    = f.label :name, class: 'form-label'
+    = f.text_field :name, class: 'form-control'
+  .col-auto
+    = f.label :phone_number, class: 'form-label'
+    = f.text_field :phone_number, class: 'form-control'
+  .col-auto
+    = f.label :email, class: 'form-label'
+    = f.text_field :email, class: 'form-control'
+  .col-auto.mt-4
+    = f.submit class: 'btn btn-primary'

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,14 +1,3 @@
 h2 Creating an entry
 
-= form_for @person, class: 'row' do |f|
-  .col-auto
-    = f.label :name, class: 'form-label'
-    = f.text_field :name, class: 'form-control'
-  .col-auto
-    = f.label :phone_number, class: 'form-label'
-    = f.text_field :phone_number, class: 'form-control'
-  .col-auto
-    = f.label :email, class: 'form-label'
-    = f.text_field :email, class: 'form-control'
-  .col-auto.mt-4
-    = f.submit class: 'btn btn-primary'
+= render 'form', person: @person

--- a/spec/features/people/new_spec.rb
+++ b/spec/features/people/new_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Create Person", type: :feature do
+  scenario "User creates a person successfully" do
+    visit new_person_path
+
+    fill_in "Name", with: "Esteban"
+    fill_in "Phone number", with: "1234567890"
+    fill_in "Email", with: "esteban@example.com"
+
+    click_button "Create Person"
+    expect(page).to have_content("Esteban")
+  end
+
+  scenario "User fails to create a person" do
+    visit new_person_path
+
+    fill_in "Name", with: ""
+    fill_in "Phone number", with: ""
+    fill_in "Email", with: ""
+    click_button "Create Person"
+
+    expect(page).to have_content("Name can't be blank")
+  end
+end


### PR DESCRIPTION
when creating a new Person entry, when the new entry is unable to be saved, a message with the error is being shown, and it will keep the values in the fields already filled out.

**Note:** View spec is not being added here since a feature spec was added, I preferred adding feature specs intead when there are user interactions

<img width="1369" alt="Screenshot 2025-01-22 at 10 13 28 AM" src="https://github.com/user-attachments/assets/e60c8f25-ce98-4461-b5f7-a65ad4323355" />
